### PR TITLE
se modifico el menu para ser compatible con safari

### DIFF
--- a/src/components/ui/molecules/Menu.vue
+++ b/src/components/ui/molecules/Menu.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="menu">
     <button
-      @focus="showMenu = !showMenu" 
+      @click="displayMenu"
       @focusout="showMenu = !showMenu"
+      ref="btnMenu"
       class="menu__btn"
     >
       <slot />
@@ -56,6 +57,10 @@
           }
           this.$emit('selected', value);
         })
+      },
+      displayMenu(){
+        this.showMenu = !this.showMenu;
+        this.$refs.btnMenu.focus();
       }
     }
   }


### PR DESCRIPTION
se genera el Focus del btn-menu dentro del método displayMenu asociado al evento Click, ya que el navegador safari no genera foco de manera automática al hacer click en un componente button.